### PR TITLE
changes rendering to be more consistent with react18 conventions

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,9 +6,6 @@
 
 body {
     margin: 0;
-    /* font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif; */
     font-family: "Roboto";
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,15 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import { BrowserRouter } from "react-router-dom";
 import "@fontsource/roboto";
 
-ReactDOM.render(
-    <BrowserRouter>
-        <App />
-    </BrowserRouter>,
-    document.getElementById("root")
+const root = createRoot(document.getElementById("root"));
+root.render(
+    <React.StrictMode>
+        <BrowserRouter>
+            <App />
+        </BrowserRouter>
+    </React.StrictMode>
 );

--- a/src/layout/Layout.js
+++ b/src/layout/Layout.js
@@ -1,4 +1,3 @@
-import { ClassNames } from "@emotion/react";
 import React from "react";
 import MainNavigation from "./MainNavigation";
 import classes from "./Layout.module.css";


### PR DESCRIPTION
Changes the way app is rendered to use ReactDOM.createRoot() and root.render(), instead of ReactDOM.render(). This removes errors which state that the previous way is no longer supported in react18.